### PR TITLE
feat(UIButtonBuilder): expose cached index operations

### DIFF
--- a/Runtime/Prefabs/Utilities.ObjectStateSwitcher.prefab
+++ b/Runtime/Prefabs/Utilities.ObjectStateSwitcher.prefab
@@ -118,7 +118,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 5175660345170042193}
         m_MethodName: SwitchToCachedIndex
-        m_Mode: 1
+        m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Runtime/SharedResources/Scripts/UIButtonBuilder.cs
+++ b/Runtime/SharedResources/Scripts/UIButtonBuilder.cs
@@ -69,13 +69,34 @@
         protected static Dictionary<string, int> cachedIndexCollection = new Dictionary<string, int>();
 
         /// <summary>
+        /// Switches the <see cref="Switcher"/> to the given index.
+        /// </summary>
+        /// <param name="index">The index to switch to.</param>
+        [RequiresBehaviourState]
+        public virtual void SwitchTo(int index)
+        {
+            Switcher.SwitchTo(index);
+            cachedIndexCollection[Switcher.name] = index;
+        }
+
+        /// <summary>
+        /// Attempts to receive the cached index for the current switcher.
+        /// </summary>
+        /// <param name="cachedIndex">The reference to the found cached index.</param>
+        /// <returns>Whether a cached index was found.</returns>
+        public virtual bool TryGetCachedIndex(out int cachedIndex)
+        {
+            return cachedIndexCollection.TryGetValue(Switcher.name, out cachedIndex);
+        }
+
+        /// <summary>
         /// Switches the <see cref="Switcher"/> to the current cached index.
         /// </summary>
+        /// <param name="defaultWhenNoCachedIndex">The index to switch to if no cached index is present.</param>
         [RequiresBehaviourState]
-        public virtual void SwitchToCachedIndex()
+        public virtual void SwitchToCachedIndex(int defaultWhenNoCachedIndex = 0)
         {
-            cachedIndexCollection.TryGetValue(Switcher.name, out int cachedIndex);
-            SwitchTo(cachedIndex);
+            SwitchTo(TryGetCachedIndex(out int cachedIndex) ? cachedIndex : defaultWhenNoCachedIndex);
         }
 
         /// <summary>
@@ -124,16 +145,6 @@
         protected virtual void Awake()
         {
             panelSize = ContainerRect.sizeDelta;
-        }
-
-        /// <summary>
-        /// Switches the <see cref="Switcher"/> to the given index.
-        /// </summary>
-        /// <param name="index">The index to switch to.</param>
-        protected virtual void SwitchTo(int index)
-        {
-            Switcher.SwitchTo(index);
-            cachedIndexCollection[Switcher.name] = index;
         }
 
         /// <summary>


### PR DESCRIPTION
The CachedIndex can now be accessed via the `TryGetCachedIndex` method
which will return the current cached index for the selected item if
one has been set, otherwise the method will return false.

The `SwitchTo(int index)` method has also been exposed publicly so
switching can happen programatically on the component and the relevant
index cache is updated accordingly.